### PR TITLE
投稿内容とユーザーを紐付ける

### DIFF
--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -14,7 +14,7 @@ class PostsController < ApplicationController
   end
 
   def create
-    post = current_user.posts.create!(post_params)
+    @post = current_user.posts.create!(post_params)
     redirect_to posts_path
   end
 
@@ -37,6 +37,6 @@ class PostsController < ApplicationController
   private
 
   def post_params
-    params.require(:post).permit(:content)
+    params.require(:post).permit(:content, :image)
   end
 end

--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -14,7 +14,7 @@ class PostsController < ApplicationController
   end
 
   def create
-    post = Post.create!(post_params)
+    post = current_user.posts.create!(post_params)
     redirect_to posts_path
   end
 
@@ -37,6 +37,6 @@ class PostsController < ApplicationController
   private
 
   def post_params
-    params.require(:post).permit(:title, :content)
+    params.require(:post).permit(:content)
   end
 end

--- a/app/models/post.rb
+++ b/app/models/post.rb
@@ -1,2 +1,3 @@
 class Post < ApplicationRecord
+    validates :content, presence: true
 end

--- a/app/models/post.rb
+++ b/app/models/post.rb
@@ -1,3 +1,4 @@
 class Post < ApplicationRecord
+    belongs_to :user
     validates :content, presence: true
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,4 +1,5 @@
 class User < ApplicationRecord
+  has_many :posts, dependent: :destroy
   # Include default devise modules. Others available are:
   # :confirmable, :lockable, :timeoutable, :trackable and :omniauthable
   devise :database_authenticatable, :registerable,

--- a/app/views/posts/index.html.erb
+++ b/app/views/posts/index.html.erb
@@ -17,6 +17,7 @@
         <th scope="row"><%= i %></th>
         <td><%= post.image %></td>
         <td><%= post.content %></td>
+        <td><%= post.user.name %></td>
         <td>
           <%= link_to "詳細", post %>
           <%= link_to "編集", edit_post_path(post) %>

--- a/app/views/posts/new.html.erb
+++ b/app/views/posts/new.html.erb
@@ -1,6 +1,6 @@
 <%# 後でBootstrapを使用した書き方に変更する %>
 <h1>新規投稿</h1>
-<%= form_with model: @post, local: true do |form| %>
+<%= form_with model: @post, local: true, multipart: :true do |form| %>
   <div>
     <%= form.label :image, "画像投稿" %>
     <%= form.file_field :image %>

--- a/db/migrate/20210203104933_create_posts.rb
+++ b/db/migrate/20210203104933_create_posts.rb
@@ -1,7 +1,7 @@
 class CreatePosts < ActiveRecord::Migration[6.1]
   def change
     create_table :posts do |t|
-      t.string :image, null: false
+      t.string :image
       t.text :content, null: false
       t.references :user, null: false, foreign_key: true
 

--- a/db/migrate/20210203104933_create_posts.rb
+++ b/db/migrate/20210203104933_create_posts.rb
@@ -1,8 +1,9 @@
 class CreatePosts < ActiveRecord::Migration[6.1]
   def change
     create_table :posts do |t|
-      t.string :image
-      t.text :content
+      t.string :image, null: false
+      t.text :content, null: false
+      t.references :user, null: false, foreign_key: true
 
       t.timestamps
     end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -13,7 +13,7 @@
 ActiveRecord::Schema.define(version: 2021_02_03_104933) do
 
   create_table "posts", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
-    t.string "image", null: false
+    t.string "image"
     t.text "content", null: false
     t.bigint "user_id", null: false
     t.datetime "created_at", precision: 6, null: false

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -13,10 +13,12 @@
 ActiveRecord::Schema.define(version: 2021_02_03_104933) do
 
   create_table "posts", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
-    t.string "image"
-    t.text "content"
+    t.string "image", null: false
+    t.text "content", null: false
+    t.bigint "user_id", null: false
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
+    t.index ["user_id"], name: "index_posts_on_user_id"
   end
 
   create_table "users", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
@@ -34,4 +36,5 @@ ActiveRecord::Schema.define(version: 2021_02_03_104933) do
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true
   end
 
+  add_foreign_key "posts", "users"
 end


### PR DESCRIPTION
### 実装内容
- 投稿内容とユーザーを紐付ける
  - postモデルにuser_idも持つためのカラムを追加。
  - userモデル
    - has_many :post, dependent: :destroy
  - postモデル
    - belongs_to :user
- postsコントローラーのcreateメソッドを修正
  - @post = Post.create(post_params)　→　@post = current_user.posts.create!(post_params)