### PR TITLE
自分の投稿を削除できるように修正

### DIFF
--- a/app/models/post.rb
+++ b/app/models/post.rb
@@ -1,7 +1,7 @@
 class Post < ApplicationRecord
     belongs_to :user
     has_many :post_likes, dependent: :destroy
-    has_many :comments
+    has_many :comments, dependent: :destroy
   # post.liked_users で post を「いいね!」しているユーザーの一覧を取得できるようになる↓
     has_many :liked_users, through: :post_likes, source: :user
     validates :content, presence: true

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,7 +1,7 @@
 class User < ApplicationRecord
   has_many :posts, dependent: :destroy
   has_many :post_likes, dependent: :destroy
-  has_many :comments
+  has_many :comments, dependent: :destroy
    # user.liked_posts で user が「いいね!」しているメッセージの一覧を取得できるようになる↓
   has_many :liked_posts, through: :post_likes, source: :post
   # Include default devise modules. Others available are:


### PR DESCRIPTION
### 修正内容
- 自分の投稿を削除できるように修正する

【仮説】
- コントローラーが間違えていないか？？
→問題なし
- モデルに間違いはないか？？
→よく確認したらcommentの関連付けにdependent: :destroyをつけておらず、投稿を削除したとしてもコメントが残ってしまう状況に。→そりゃエラー出るわ。

【対処】
- UserモデルとPostモデルのcommentの関連付けにdependent: :destroyを記述
→解決！！

### 参考
- [スタックオーバーフロー](https://stackoverflow.com/questions/45522580/rails-activerecordinvalidforeignkey-in-articlescontrollerdestroy/45522674)