### PR TITLE
お気に入りした投稿を1ページに表示できる件数を制限

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -33,6 +33,7 @@ gem 'devise-i18n'
 gem 'carrierwave'
 gem 'pry-rails'
 gem 'activeadmin'
+gem 'kaminari'
 group :development, :test do
   # Call 'byebug' anywhere in the code to stop execution and get a debugger console
   gem 'byebug', platforms: [:mri, :mingw, :x64_mingw]

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -293,6 +293,7 @@ DEPENDENCIES
   devise
   devise-i18n
   jbuilder (~> 2.7)
+  kaminari
   listen (~> 3.3)
   mysql2 (~> 0.5)
   pry-rails

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -1,6 +1,6 @@
 class UsersController < ApplicationController
   def show
     @user = User.all
-    @liked_posts = current_user.liked_posts
+    @liked_posts = current_user.liked_posts.page(params[:page]).per(5)
   end
 end

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -1,5 +1,6 @@
 class UsersController < ApplicationController
   def show
     @user = User.all
+    @liked_posts = current_user.liked_posts
   end
 end

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -4,7 +4,7 @@
   <%= current_user.name %><br>
   <%= current_user.introduction %><br>
   <%= link_to 'アカウント編集画面へ', edit_user_registration_path %><br>
-  <% current_user.liked_posts.each do |likes| %>
+  <% @liked_posts.each do |likes| %>
     <table style="border: 1px solid black ;">
       <td><%= image_tag likes.image.url %></td>
       <td><%= likes.content %></td>


### PR DESCRIPTION
### 実装内容
- お気に入りした投稿を1ページに５件まで表示できるように設定。
  - gem(kaminari)を使用

