### PR TITLE
ユーザーがお気に入りした投稿をユーザーページから操作できるように修正

### DIFF
--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -24,7 +24,7 @@ class PostsController < ApplicationController
   end
 
   def edit
-    @post = Post.find(params[:id])
+    @post = Post.find_by(id: params[:id])
   end
 
   def update

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -2,6 +2,5 @@ class UsersController < ApplicationController
   def show
     @user = User.all
     @liked_posts = current_user.liked_posts.page(params[:page]).per(5)
-    @post = Post.all
   end
 end

--- a/app/views/posts/index.html.erb
+++ b/app/views/posts/index.html.erb
@@ -11,7 +11,7 @@
       <p><%= post.content %></p>
       <%= link_to "詳細", post %>
       <% if current_user.id == post.user_id %>
-        <%= link_to "編集", edit_post_path(:user_id) %>
+        <%= link_to "編集", edit_post_path(post) %>
         <%= link_to "削除", post, method: :delete, data: { confirm: "削除しますか?" } %>
       <% end %>
       <% if current_user.id != post.liked_by?(current_user)  %>

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -36,8 +36,8 @@
         <p><%= likes.content %></p>
         <%= link_to "詳細", post_path(likes) %>
         <% if current_user.id == likes.user_id %>
-          <%= link_to "編集", edit_post_path(:user_id) %>
-          <%= link_to "削除", post_path, method: :delete, data: { confirm: "削除しますか?" } %>
+          <%= link_to "編集", edit_post_path(likes) %>
+          <%= link_to "削除", post_path(likes), method: :delete, data: { confirm: "削除しますか?" } %>
         <% end %>
         <% if current_user.id != likes.liked_by?(current_user)  %>
           <td><% if likes.liked_by?(current_user) %>

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -34,16 +34,16 @@
       <div class="like-user-details">
         <p class="user-profile-image like-name"><%= image_tag likes.user.image.url, class: 'post-user-image' %><%= likes.user.name %></p>
         <p><%= likes.content %></p>
-        <%= link_to "詳細", post_path(@post.ids) %>
+        <%= link_to "詳細", post_path(likes) %>
         <% if current_user.id == likes.user_id %>
           <%= link_to "編集", edit_post_path(:user_id) %>
           <%= link_to "削除", post_path, method: :delete, data: { confirm: "削除しますか?" } %>
         <% end %>
         <% if current_user.id != likes.liked_by?(current_user)  %>
           <td><% if likes.liked_by?(current_user) %>
-              <%= link_to '★', post_post_likes_path(@post), method: :delete %>
+              <%= link_to '★', post_post_likes_path(likes), method: :delete %>
             <% else %>
-              <%= link_to '☆', post_post_likes_path(@post), method: :post %>
+              <%= link_to '☆', post_post_likes_path(likes), method: :post %>
             <% end %></td>
           <td>
           <% end %>


### PR DESCRIPTION
### 修正内容
- 詳細、編集、削除ができない状態になっていたので、ユーザーページから詳細、編集、削除などの操作ができるように修正